### PR TITLE
Make SSL Version configurable

### DIFF
--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -62,6 +62,8 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
   # Verify the identity of the other end of the SSL connection.
   config :ssl_verify, :validate => :boolean, :default => true
 
+  config :ssl_version, :validate => :string
+
   # facility label for syslog message
   config :facility, :validate => FACILITY_LABELS, :required => true
 
@@ -120,6 +122,9 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
         else
           ssl.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
+
+        ssl.ssl_version = @ssl_version.to_sym if @ssl_version
+
         @client_socket = OpenSSL::SSL::SSLSocket.new(@client_socket, ssl)
         @client_socket.sync_close = true
       end


### PR DESCRIPTION
JRuby defaults to TLSv1.0, but we should start using something newer
here (preferably TLSv1.2). This adds support for a configuration option
to control the TLS version to use.

By default, none is set and the default (TLSv1.0) is used.

---

cc @fancyremarker @usernotfound